### PR TITLE
Fix .gitignore and put back all .gradle files that accidentally deleted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,12 @@
 *.iml
-*.gradle
+.gradle
 local.properties
 .idea
+#/.idea/workspace.xml
+#/.idea/libraries
 .DS_Store
 build
 captures
 app/mirror
+projectFilesBackup/
+.externalNativeBuild

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,0 +1,35 @@
+apply plugin: 'com.android.application'
+
+android {
+    compileSdkVersion 24
+    buildToolsVersion "24.0.2"
+    defaultConfig {
+        applicationId "belajar.app.sunshine"
+        minSdkVersion 17
+        targetSdkVersion 24
+        versionCode 1
+        versionName "1.0"
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+    }
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    compile fileTree(include: ['*.jar'], dir: 'libs')
+    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+        exclude group: 'com.android.support', module: 'support-annotations'
+    })
+    compile 'com.android.support:appcompat-v7:24.2.1'
+    testCompile 'junit:junit:4.12'
+    compile 'com.mcxiaoke.volley:library:1.0.19'
+    compile 'com.google.code.gson:gson:2.8.0'
+    compile 'com.android.support:design:24.2.1'
+    compile 'com.android.support:recyclerview-v7:24.2.1'
+    compile 'com.android.support:cardview-v7:24.2.1'
+    compile 'com.github.bumptech.glide:glide:3.7.0'
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,23 @@
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:2.2.1'
+
+        // NOTE: Do not place your application dependencies here; they belong
+        // in the individual module build.gradle files
+    }
+}
+
+allprojects {
+    repositories {
+        jcenter()
+    }
+}
+
+task clean(type: Delete) {
+    delete rootProject.buildDir
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+include ':app'


### PR DESCRIPTION
From the last 2 commits, i accidentally removed all **.gradle** files from the project that made the project not working on Android Studio, and there is a wrong rule in **.gitignore** file, ***.gradle** should be **.gradle**, since it is a directory. 

In this commit i want fix the error by putting back all the .gradle files that accidentally deleted and update the rules of .gitignore.